### PR TITLE
feat: implement Label element for form control captions

### DIFF
--- a/Sources/Slipstream/W3C/Elements/Forms/Label.swift
+++ b/Sources/Slipstream/W3C/Elements/Forms/Label.swift
@@ -22,7 +22,7 @@ public struct Label<Content>: View, Sendable where Content: View {
   /// - Parameters:
   ///   - htmlFor: The id of the form control that this label is associated with.
   ///   - content: A view builder that creates the label's content.
-  public init(htmlFor: String? = nil, @ViewBuilder content: @escaping @Sendable () -> Content) {
+  public init(for htmlFor: String? = nil, @ViewBuilder content: @escaping @Sendable () -> Content) {
     self.content = content
     self.htmlFor = htmlFor
   }
@@ -32,8 +32,8 @@ public struct Label<Content>: View, Sendable where Content: View {
   /// - Parameters:
   ///   - text: The text content of the label.
   ///   - htmlFor: The id of the form control that this label is associated with.
-  public init(_ text: String, htmlFor: String? = nil) where Content == DOMString {
-    self.init(htmlFor: htmlFor) {
+  public init(_ text: String, for htmlFor: String? = nil) where Content == DOMString {
+    self.init(for: htmlFor) {
       DOMString(text)
     }
   }
@@ -43,7 +43,7 @@ public struct Label<Content>: View, Sendable where Content: View {
   /// - Parameter controlId: The id of the form control.
   /// - Returns: A new label with the specified form control association.
   public func htmlFor(_ controlId: String) -> Label<Content> {
-    Label(htmlFor: controlId, content: content)
+    Label(for: controlId, content: content)
   }
 
   @_documentation(visibility: private)

--- a/Tests/SlipstreamTests/W3C/Forms/LabelTests.swift
+++ b/Tests/SlipstreamTests/W3C/Forms/LabelTests.swift
@@ -14,11 +14,11 @@ struct LabelTests {
   }
 
   @Test func withHtmlFor() throws {
-    try #expect(renderHTML(Label("Menu", htmlFor: "menu-toggle")) == #"<label for="menu-toggle">Menu</label>"#)
+    try #expect(renderHTML(Label("Menu", for: "menu-toggle")) == #"<label for="menu-toggle">Menu</label>"#)
   }
 
   @Test func withContentAndHtmlFor() throws {
-    try #expect(renderHTML(Label(htmlFor: "terms") {
+    try #expect(renderHTML(Label(for: "terms") {
       DOMString("I agree to the terms")
     }) == #"<label for="terms">I agree to the terms</label>"#)
   }
@@ -29,11 +29,11 @@ struct LabelTests {
 
   @Test func mobileMenuToggleUseCase() throws {
     // Test the specific use case for mobile menu toggle
-    try #expect(renderHTML(Label("☰", htmlFor: "menu-toggle")) == #"<label for="menu-toggle">☰</label>"#)
+    try #expect(renderHTML(Label("☰", for: "menu-toggle")) == #"<label for="menu-toggle">☰</label>"#)
   }
 
   @Test func complexContent() throws {
-    try #expect(renderHTML(Label(htmlFor: "checkbox") {
+    try #expect(renderHTML(Label(for: "checkbox") {
       DOMString("Complex ")
       DOMString("label")
     }) == #"<label for="checkbox">Complex label</label>"#)


### PR DESCRIPTION
Partially adresses #25

<!-- Link to an issue(s) this PR fixes -->

#### :zap: Summary

This PR implements a `Label` element for form control captions in Slipstream, based on the existing `Button.swift` implementation. I am using it for a mobile menu toggle implemented with CSS only on a [dev website](https://github.com/21-DOT-DEV/websites/pull/2#issuecomment-3189906640).

Includes:
- `Label` element supporting static text or custom content via `@ViewBuilder`.
- Ability to bind labels to specific form controls with `htmlFor`.
- Unit tests covering basic text, content, `htmlFor` usage, and a mobile menu toggle scenario.

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [x] Add tests
- [x] Add documentation