### PR TITLE
feat: implement Header element

### DIFF
--- a/Sources/Slipstream/W3C/Elements/Sections/Header.swift
+++ b/Sources/Slipstream/W3C/Elements/Sections/Header.swift
@@ -1,0 +1,28 @@
+/// A view that represents a group of introductory or navigational aids.
+///
+/// ```swift
+/// struct MySiteHeader: View {
+///   var body: some View {
+///     Header {
+///       Navigation {
+///         Link("About", destination: URL(string: "/about"))
+///       }
+///     }
+///   }
+/// }
+/// ```
+///
+/// - SeeAlso: W3C [`header`](https://html.spec.whatwg.org/multipage/sections.html#the-header-element) specification.
+@available(iOS 17.0, macOS 14.0, *)
+public struct Header<Content>: W3CElement where Content: View {
+  @_documentation(visibility: private)
+  public let tagName: String = "header"
+
+  @_documentation(visibility: private)
+  @ViewBuilder public let content: @Sendable () -> Content
+
+  /// Creates a Header view.
+  public init(@ViewBuilder content: @escaping @Sendable () -> Content) {
+    self.content = content
+  }
+}

--- a/Tests/SlipstreamTests/W3C/HeaderTests.swift
+++ b/Tests/SlipstreamTests/W3C/HeaderTests.swift
@@ -1,0 +1,23 @@
+import Testing
+
+import Slipstream
+
+struct HeaderTests {
+  @Test func emptyBlock() throws {
+    try #expect(renderHTML(Header {}) == "<header></header>")
+  }
+
+  @Test func withText() throws {
+    try #expect(renderHTML(Header {
+      DOMString("Hello, world!")
+    }) == """
+<header>
+ Hello, world!
+</header>
+""")
+  }
+
+  @Test func attribute() throws {
+    try #expect(renderHTML(Header {}.language("en")) == #"<header lang="en"></header>"#)
+  }
+}


### PR DESCRIPTION
Partially adresses #25

#### :zap: Summary

This PR implements an HTML `Header` element for Slipstream, based on the existing `Footer.swift` and `Section.swift` implementations. I am using it for a [dev website](https://github.com/21-DOT-DEV/websites/pull/2#issuecomment-3189906640).

Includes:
- `Header` element with a `tagName` of `"header"`.
- Support for custom content passed through `@ViewBuilder`.
- Unit tests covering empty state, text content, and attribute usage.

#### :ballot_box_with_check: Checklist

- [x] Check locally
- [x] Add tests
- [x] Add documentation