### PR TITLE
Add ForEach view for iterating over collections

### DIFF
--- a/Sources/Slipstream/Fundamentals/ViewBuilder/ForEachView.swift
+++ b/Sources/Slipstream/Fundamentals/ViewBuilder/ForEachView.swift
@@ -1,0 +1,60 @@
+import Foundation
+import SwiftSoup
+
+/// A structure that computes views on demand from an underlying collection of data.
+///
+/// `ForEach` is a declarative way to create views from a collection, similar to SwiftUI's ForEach.
+/// It leverages Slipstream's existing `ArrayView` and `ViewBuilder.buildArray` infrastructure
+/// to provide type-safe collection rendering without requiring `RawHTML` workarounds.
+///
+/// ## Usage
+///
+/// ```swift
+/// ForEach(items, id: \.id) { item in
+///     Text(item.title)
+/// }
+/// ```
+///
+/// ## Key Features
+/// - Works with any `RandomAccessCollection`
+/// - Requires a key path for element identification
+/// - Integrates seamlessly with `@ViewBuilder`
+/// - Eliminates need for `RawHTML(array.map{}.joined())` patterns
+@_documentation(visibility: private)
+@available(iOS 17.0, macOS 14.0, *)
+public struct ForEach<Data, ID, Content>: View where Data: RandomAccessCollection, ID: Hashable, Content: View {
+    
+    /// The rendered views from the collection
+    private let arrayView: ArrayView
+    
+    /// Creates a ForEach view that iterates over a collection.
+    /// - Parameters:
+    ///   - data: The collection to iterate over
+    ///   - id: Key path to a unique identifier for each element
+    ///   - content: ViewBuilder closure that creates content for each element
+    public init(_ data: Data, id: KeyPath<Data.Element, ID>, @ViewBuilder content: @escaping (Data.Element) -> Content) {
+        let views = data.map { element in
+            content(element)
+        }
+        self.arrayView = ArrayView(array: views)
+    }
+    
+    public func render(_ container: Element, environment: EnvironmentValues) throws {
+        try arrayView.render(container, environment: environment)
+    }
+}
+
+/// Convenience initializer for collections where elements conform to `Identifiable`.
+@available(iOS 17.0, macOS 14.0, *)
+extension ForEach where Data.Element: Identifiable, ID == Data.Element.ID {
+    /// Creates a ForEach view for `Identifiable` elements.
+    /// - Parameters:
+    ///   - data: The collection to iterate over (elements must be `Identifiable`)
+    ///   - content: ViewBuilder closure that creates content for each element
+    public init(_ data: Data, @ViewBuilder content: @escaping (Data.Element) -> Content) {
+        let views = data.map { element in
+            content(element)
+        }
+        self.arrayView = ArrayView(array: views)
+    }
+}

--- a/Tests/SlipstreamTests/ForEachTests.swift
+++ b/Tests/SlipstreamTests/ForEachTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import Testing
+@testable import Slipstream
+
+struct TestItem: Identifiable {
+    let id: String
+    let title: String
+}
+
+struct TestItemWithoutId {
+    let name: String
+    let value: Int
+}
+
+@Suite
+struct ForEachTests {
+    
+    @Test("ForEach with Identifiable elements")
+    func forEachWithIdentifiableElements() throws {
+        let items = [
+            TestItem(id: "1", title: "First"),
+            TestItem(id: "2", title: "Second"),
+            TestItem(id: "3", title: "Third")
+        ]
+        
+        let html = try renderHTML(
+            ForEach(items) { item in
+                Text(item.title)
+            }
+        )
+        
+        #expect(html.contains("First"))
+        #expect(html.contains("Second"))
+        #expect(html.contains("Third"))
+    }
+    
+    @Test("ForEach with custom id keypath")
+    func forEachWithCustomKeyPath() throws {
+        let items = [
+            TestItemWithoutId(name: "Alpha", value: 1),
+            TestItemWithoutId(name: "Beta", value: 2),
+            TestItemWithoutId(name: "Gamma", value: 3)
+        ]
+        
+        let html = try renderHTML(
+            ForEach(items, id: \.name) { item in
+                Div {
+                    Text(item.name)
+                    Text("Value: \(item.value)")
+                }
+            }
+        )
+        
+        #expect(html.contains("Alpha"))
+        #expect(html.contains("Value: 1"))
+        #expect(html.contains("Beta"))
+        #expect(html.contains("Value: 2"))
+        #expect(html.contains("Gamma"))
+        #expect(html.contains("Value: 3"))
+    }
+    
+    @Test("ForEach with Links")
+    func forEachWithLinks() throws {
+        struct NavigationItem {
+            let title: String
+            let href: String
+        }
+        
+        let navItems = [
+            NavigationItem(title: "Home", href: "/"),
+            NavigationItem(title: "About", href: "/about"),
+            NavigationItem(title: "Contact", href: "/contact")
+        ]
+        
+        let html = try renderHTML(
+            ForEach(navItems, id: \.href) { item in
+                Link(item.title, destination: URL(string: item.href))
+            }
+        )
+        
+        #expect(html.contains("<a href=\"/\">Home</a>"))
+        #expect(html.contains("<a href=\"/about\">About</a>"))
+        #expect(html.contains("<a href=\"/contact\">Contact</a>"))
+    }
+    
+    @Test("ForEach with modifiers")
+    func forEachWithModifiers() throws {
+        let items = ["Red", "Green", "Blue"]
+        
+        let html = try renderHTML(
+            ForEach(items, id: \.self) { color in
+                Text(color)
+                    .textColor(.palette(.red, darkness: 500))
+            }
+        )
+        
+        #expect(html.contains("text-red-500"))
+        #expect(html.contains("Red"))
+        #expect(html.contains("Green"))
+        #expect(html.contains("Blue"))
+    }
+    
+    @Test("ForEach empty collection")
+    func forEachEmptyCollection() throws {
+        let items: [TestItem] = []
+        
+        let html = try renderHTML(
+            Div {
+                ForEach(items) { item in
+                    Text(item.title)
+                }
+                Text("No items")
+            }
+        )
+        
+        #expect(html.contains("No items"))
+        #expect(!html.contains("First"))
+    }
+}


### PR DESCRIPTION

#### :zap: Summary

This PR introduces a new ForEachView component to Slipstream, enabling iteration over collections to dynamically render repeated content. It is inspired by SwiftUI’s ForEach, but tailored for Slipstream’s ViewBuilder system. For example:

```swift
ForEach(articles, id: \.id) { article in
    ArticleView(article: article)
}
```
The implementation provides type safety through generics and RandomAccessCollection constraints, and streamlines the rendering of list-based UI components by supporting both Identifiable elements and explicit id key paths.

Unit tests cover:
	•	Iteration with Identifiable collections
	•	Iteration with custom id key paths
	•	Rendering links and styled elements via modifiers
	•	Handling empty collections with explicit fallback content

#### :ballot_box_with_check: Checklist

- [x] Checked locally
- [x] Add tests
- [x] Add documentation