### PR TITLE
fix: prevent empty condition prefix from adding stray colon to Tailwind classes

### DIFF
--- a/Sources/Slipstream/TailwindCSS/TailwindClassModifier.swift
+++ b/Sources/Slipstream/TailwindCSS/TailwindClassModifier.swift
@@ -51,7 +51,12 @@ private struct TailwindClassModifierView<Content: View>: View {
     for child in shadowDOM.children() {
       for className in classNames.sorted() {
         if let condition {
-          try child.addClass("\(condition.tailwindClassModifiers):\(className)")
+          let modifiers = condition.tailwindClassModifiers
+          if modifiers.isEmpty {
+            try child.addClass(className)
+          } else {
+            try child.addClass("\(modifiers):\(className)")
+          }
         } else {
           try child.addClass(className)
         }

--- a/Tests/SlipstreamTests/TailwindCSS/Spacing/PaddingTests.swift
+++ b/Tests/SlipstreamTests/TailwindCSS/Spacing/PaddingTests.swift
@@ -42,4 +42,13 @@ struct PaddingTests {
         )) == #"<div class="pt-0 md:pr-1"></div>"#
     )
   }
+
+  @Test func smallBreakpointProducesNoPrefix() throws {
+    // .small is treated as the base case in Tailwind's mobile-first model,
+    // so it should produce no prefix (not a stray colon like ":px-2")
+    try #expect(
+      renderHTML(Div {}.padding(.horizontal, 8, condition: .startingAt(.small)))
+        == #"<div class="px-2"></div>"#
+    )
+  }
 }


### PR DESCRIPTION
- Check if condition.tailwindClassModifiers is empty before adding colon separator
- Add test verifying .small breakpoint produces no prefix (base case in mobile-first model)